### PR TITLE
Support inherited documentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "del": "^2.2.2",
     "elix": "elix/elix#master",
     "express": "^4.14.0",
+    "fs-extra": "^2.1.2",
     "gulp": "^3.9.1",
     "gulp-jshint": "^2.0.4",
     "gulp-rename": "^1.2.2",

--- a/server/buildDocs.js
+++ b/server/buildDocs.js
@@ -1,11 +1,9 @@
 /*jslint node: true */
 'use strict';
 
-const fs = require('fs');
+const fs = require('fs-extra');
 const jsDocParse = require('jsdoc-parse');
-const dmd = require('dmd');
-const Readable = require('stream').Readable;
-const marked = require('marked');
+const promisify = require('./promisify');
 
 const outputPath = './build/docs/';
 
@@ -15,97 +13,72 @@ const outputPath = './build/docs/';
 const sourceDirs = ['node_modules/elix/elements', 'node_modules/elix/mixins'];
 
 //
-// Build the global docsList array for use in building the package's README.md documentation
+// docsList is an array of objects listing the name, src, and dest of each
+// element/mixin/utility file:
+//
+// Eg:
+// [{name: MyClass, src: '.../myClass.js', dest: './build/docs/myClass.json'}, ...]
 //
 let docsList;
-sourceDirs.forEach((dir) => {
-  docsList = docsList ? docsList.concat(buildDocsList(dir)) : buildDocsList(dir);
-});
+
+//
+// unextendedDocumentationMap is the dictionary of object names to jsDoc
+// json documentation. The json documentation is the jsDoc for the
+// source file alone, not extended with @mixes or @extends references.
+//
+// Eg:
+// { 'myObject1': {docThing1: 'blah', docThing2: 'blah'},
+//   'myObject2': {docThing1: 'blah', docThing2: 'blah'},
+//   ...
+// }
+//
+// We use unextendedDocumentationMap as a cache of each file's raw jsDoc
+// documentation from which we build extended documentation that gets
+// written to build/docs.
+//
+let unextendedDocumentationMap = {};
+
+function buildDocsList() {
+  return mapAndChain(sourceDirs, buildDocsListForDirectory)
+  .catch(error => {
+    console.error(`buildDocsList: ${error}`);
+  });
+}
 
 //
 // Build the portion of docsList that represents the individual source files
 // within the specified directory.
 //
-function buildDocsList(dirName) {
-  return fs.readdirSync(`${dirName}/`)
-    .filter(file => file.endsWith('.js'))
+function buildDocsListForDirectory(dirName) {
+  const readdirPromise = promisify(fs.readdir);
+  
+  return readdirPromise(`${dirName}/`)
+  .then((files) => {
+    let array = files.filter(file => file.endsWith('.js'))
     .map(file => {
       const fileRoot = file.replace('.js', '');
-      return {
+      let obj = {
+        name: fileRoot,
         src: `${dirName}/${file}`,
-        destJSON: `${outputPath}${fileRoot}.json`,
-        destMD: `${outputPath}${fileRoot}.md`,
-        destHTML: `${outputPath}${fileRoot}.html`
+        dest: `${outputPath}${fileRoot}.json`
       };
-    });
-}
-
-function buildMarkdownDoc(docItem) {
-  console.log('Building ' + docItem.destJSON + ' from ' + docItem.src);
-
-  return parseScriptToJSDocJSON(docItem.src)
-  .then(json => {
-    return mergeMixinDocs(json);
-  })
-  .then(json => {
-    // Sort the array, leaving the order:0 item alone at the
-    // front of the list (the class identifier section)
-    json.sort((a, b) => {
-      if (a.order === 0) { return -1; }
-      if (b.order === 0) { return 1; }
-
-      return a.name.localeCompare(b.name);
-    });
-
-    // Set the order value
-    json.map((item, index) => {
-      item.order = index;
+      
+      // Prepare an entry in the unextendedDocumentationMap
+      unextendedDocumentationMap[obj.name] = {};
+      
+      return obj;
     });
     
-    return json;
+    docsList = docsList ? docsList.concat(array) : array;
   })
-  .then(function(json) {
-    // Write the json to output file
-    return new Promise(function(resolve, reject) {
-      fs.writeFile(docItem.destJSON, JSON.stringify(json, null, 2), 'utf-8', function (err) {
-        if (err) {
-          return reject(err);
-        }
-        resolve(json);
-      });
-    });
-  /*  
-  })
-  .then(function(json) {
-    // Convert json to markdown
-    return parseJSONToMarkdown(json);
-  })
-  .then(function(markdown) {
-    // Write the markdown to the output file
-    return new Promise(function(resolve, reject) {
-      fs.writeFile(docItem.destMD, markdown, 'utf-8', function(err) {
-        if (err) {
-          return reject(err);
-        }
-        resolve(markdown);
-      });
-    });
-  })
-  .then(function(markdown) {
-    // Convert markdown to HTML and write to output file
-    let html = marked(markdown);
-    return new Promise(function(resolve, reject) {
-      fs.writeFile(docItem.destHTML, html, 'utf-8', function(err) {
-        if (err) {
-          return reject(err);
-        }
-        resolve();
-      });
-    });
-  */
+  .catch(error => {
+    console.error(`buildDocsListForDirectory: ${error}`);
   });
 }
 
+//
+// Uses jsdoc-parse to convert a .js file to jsDoc json
+//
 function parseScriptToJSDocJSON(src) {
   return new Promise((resolve, reject) => {
     // Start by parsing the jsdoc into a stream which will contain
@@ -128,71 +101,197 @@ function parseScriptToJSDocJSON(src) {
   });
 }
 
-function parseJSONToMarkdown(json) {
-  return new Promise(function(resolve, reject) {
-    // Create a new readable stream, holding the stringified JSON
-    let string = '';
-    const s = new Readable();
-    s._read = function noop() {};
-    s.push(JSON.stringify(json));
-    s.push(null);
+//
+// Build the jsDoc json for a specified source file and stuff
+// it in the unextendedDocumentationMap keyed on the object's name
+//
+function buildUnextendedJson(docItem) {
+  console.log(`Building cached and unextended jsdoc json for ${docItem.name} from ${docItem.src}`);
 
-    // Use dmd to create the markdown string which we will
-    // write to an output .md file (NYI)
-    const partials = [
-      './server/md-templates/main.hbs',
-      './server/md-templates/scope.hbs',
-      './server/md-templates/mixes.hbs',
-      './server/md-templates/mixin-linked-type-list.hbs'];
-    const dmdStream = dmd({partial: partials, 'global-index-format': 'none', 'group-by': ['none']});
-    s.pipe(dmdStream);
-    dmdStream.setEncoding('utf8');
-    dmdStream.on('data', data => {
-      string += data;
-    })
-    .on('end', () => {
-      // string now holds the markdown text
-      resolve(string);
-    })
-    .on('error', err => {
-      reject(err);
-    });
+  return parseScriptToJSDocJSON(docItem.src)
+  .then(json => {
+    unextendedDocumentationMap[docItem.name] = json;
+  })
+  .catch(error => {
+    console.error(`buildUnextendedJson: ${error}`);
   });
 }
 
-function mergeMixinDocs(componentJson) {
-  if (componentJson.length === 0 ||
-      componentJson[0].mixes == null || componentJson[0].mixes === undefined) {
-    return componentJson;
+//
+// After the unextendedDocumentationMap cache is built, we build
+// the extended documentation for objects having @extend and @mixes
+// attributes.
+//
+// buildAndWriteExtendedJson takes a single item from the docsList array
+// and builds the extended documentation for that item.
+//
+function buildAndWriteExtendedJson(docsListItem) {
+  const writeJsonPromise = promisify(fs.writeJson);
+  
+  // Make a copy of the unextended json so we don't corrupt the cache
+  let srcJson = unextendedDocumentationMap[docsListItem.name];
+  let componentJson = cloneJSON(srcJson);
+  
+  // Initialize the componentJson with an array parallel to
+  // the mixes array, specifying the origin class inserting the mixin
+  componentJson[0].mixinOrigins = [];
+  if (componentJson[0].mixes != null && componentJson[0].mixes !== undefined) {
+    componentJson[0].mixinOrigins = componentJson[0].mixes.map(mixin => {
+      return componentJson[0].name;
+    });
   }
 
-  const mixins = componentJson[0].mixes.map(mixin => {
-    const fileName = mixin + '.js';
+  return mergeExtensionDocs(componentJson)
+  .then((json) => {
+    // Sort the array, leaving the order:0 item alone at the
+    // front of the list (the class identifier section)
+    json.sort((a, b) => {
+      if (a.order === 0) { return -1; }
+      if (b.order === 0) { return 1; }
 
-    for (let i = 0; i < sourceDirs.length; i++) {
-      const dir = sourceDirs[i];
-      const fullPath = `${dir}/${fileName}`;
-      if (fs.existsSync(fullPath)) {
-        return fullPath;
-      }  
-    }
+      return a.name.localeCompare(b.name);
+    });
+
+    // Set the order value
+    json.map((item, index) => {
+      item.order = index;
+    });
     
-    return '';
+    return json;
+  })
+  .then((json) => {
+    console.log(`Writing ${docsListItem.dest}`);
+    writeJsonPromise(docsListItem.dest, json, {spaces: 2});
+  })
+  .catch(error => {
+    console.error(`buildAndWriteExtendedJson: ${error}`);
   });
-
-  const hostId = componentJson[0].id;
-  return mapAndChain(mixins, mixin => mergeMixinIntoBag(mixin, componentJson, hostId))
-  .then(() =>
-    componentJson
-  );
 }
 
+//
+// Recursive function that extends the root item's mixin array, and extends
+// an array of names representing inheritance items that need to be parsed
+// and added to the root item.
+//
+// This function is first called with the root item as the json parameter.
+// There's nothing asynchronous about this work; the function is used as
+// a utility and does not return a Promise.
+//
+function buildAugmentsListAndExtendMixinsArray(json, augmentsArray, mixinArray) {
+  if (json[0].augments == null || json[0].augments === undefined) {
+    // Break the recursive chain by returning without another recursive call
+    return;
+  }  
+  
+  // We're interested only in single-inheritance
+  const augmentsName = json[0].augments[0];
+  const augmentsItem = unextendedDocumentationMap[augmentsName];
+  if (augmentsItem == null || augmentsItem === undefined) {
+    // Break the recursive chain by returning without another recursive call
+    return;
+  }
+
+  if (augmentsItem[0].mixes != null 
+      && augmentsItem[0].mixes !== undefined 
+      && augmentsItem[0].mixes.length > 0) {
+        
+    for (let i = 0; i < augmentsItem[0].mixes.length; i++) {
+      mixinArray.push({mixin: augmentsItem[0].mixes[i], source: augmentsName});
+    }
+  }
+  
+  augmentsArray.push(augmentsName);
+  return buildAugmentsListAndExtendMixinsArray(augmentsItem, augmentsArray, mixinArray);
+}
+
+//
+// mergeExtensionDocs does the work of adding the @extends and @mixes
+// documentation to the original, unextended jsDoc documentation json object.
+// The componentJson object is the cloned json mapped from the
+// unextendedDocumentationMap cache, and is updated with extended documentation
+// and eventually written to file.
+//
+function mergeExtensionDocs(componentJson) {
+  if (componentJson.length === 0) {
+    return Promise.resolve(componentJson);
+  }
+  
+  //
+  // First, walk the inheritance list, adding to the root item's mixin array,
+  // and building an array of augments/extends items
+  //
+  
+  let augmentsList = [];
+  let mixinsList = [];
+  buildAugmentsListAndExtendMixinsArray(componentJson, augmentsList, mixinsList);
+
+  //
+  // We create a new field, "inheritance," which is an array of object names
+  // the documented item inherits from, gleaned from walking each object's
+  // augments array. We could have updated the augments array, but instead
+  // we choose to create a new field so we don't tamper with augment's original
+  // intention.
+  //
+  componentJson[0].inheritance = augmentsList;
+
+  //
+  // We update the object's mixes field to include those mixins contributed
+  // by @extends objects. We create a mixinOrigins array that is identically
+  // sized to the mixins field, and contains the name of the contributing
+  // class. The two arrays can be used to build documentation where we
+  // specify, say, a method that is defined by FooMixin, and where
+  // FooMixin is contributed by/inherited from class Bar.
+  //
+  if (mixinsList.length > 0) {
+    if (componentJson[0].mixes == null || componentJson[0].mixes === undefined) {
+      componentJson[0].mixes = [];
+    }
+
+    const newMixins = mixinsList.map(item => {
+      return item.mixin;
+    });
+    const newMixinsSources = mixinsList.map(item => {
+      return item.source;
+    });
+    componentJson[0].mixes = componentJson[0].mixes.concat(newMixins);
+    componentJson[0].mixinOrigins = componentJson[0].mixinOrigins.concat(newMixinsSources);
+  }
+  
+  const hostId = componentJson[0].id;
+
+  // Merge the @extends class documentation into componentJson
+  augmentsList.forEach((augmentsItem) => {
+    mergeExtensionIntoBag(augmentsItem, componentJson, hostId);
+  });
+
+  // Merge the @mixes class documentation into componentJson
+  let mixes = componentJson[0].mixes;
+  if (mixes != null && mixes !== undefined && mixes.length > 0) {
+    mixes.forEach(mixin => {
+      mergeExtensionIntoBag(mixin, componentJson, hostId);
+    });
+  }
+
+  return Promise.resolve(componentJson);
+}
+
+//
+// Helper function that resolves the name to be referenced
+// by the origininalmemberof field.
+//
 function resolveOriginalMemberOf(omo) {
   if (omo !== undefined) {
     let strings = omo.split(/:|~/);
     switch (strings.length) {
       case 1:
-        omo = `${strings[0]}Mixin`;
+        // First test to see if strings[0] represents an inherited object
+        const trial = strings[0];
+        if (unextendedDocumentationMap[trial] != null) {
+          omo = trial;
+        }
+        else {
+          omo = `${trial}Mixin`;
+        }
         break;
       case 3:
         omo = strings[1];
@@ -205,39 +304,98 @@ function resolveOriginalMemberOf(omo) {
   return omo;
 }
 
-function mergeMixinIntoBag(mixinPath, componentJson, hostId) {
-  return parseScriptToJSDocJSON(mixinPath)
-  .then(mixinJson => {
-    for (let i = 1; i < mixinJson.length; i++) {
-      if (mixinJson[i].memberof != null && mixinJson[i].memberof != hostId) {
-        mixinJson[i].originalmemberof = resolveOriginalMemberOf(mixinJson[i].memberof);
-        mixinJson[i].memberof = hostId;
-      }
-      componentJson.push(mixinJson[i]);
+//
+// Merge a mixin or inherited class data into the root item's json
+//
+function mergeExtensionIntoBag(extensionName, componentJson, hostId) {
+  const extensionJson = cloneJSON(unextendedDocumentationMap[extensionName]);
+
+  for (let i = 1; i < extensionJson.length; i++) {
+    const originalmemberof = resolveOriginalMemberOf(extensionJson[i].memberof);
+    extensionJson[i].originalmemberof = originalmemberof;
+    extensionJson[i].memberof = hostId;
+    
+    //
+    // We specify that the new documentation item is inherited from the
+    // originalmemberof object if we can find originalmemberof in the
+    // root item's inheritance array.
+    //
+    // Otherwise, we test if the originalmemberof and memberof fields of
+    // the new documentation items are different, which would be the case
+    // if the new documentation item is contributed from a mixin. In that
+    // case, we look for originalmemberof within the root item's array
+    // of mixins, and then map the inheritedfrom field from the root item's
+    // mixinOrigins array.
+    //
+    if (componentJson[0].inheritance.indexOf(originalmemberof) >= 0) {
+      extensionJson[i].inheritedfrom = originalmemberof;
     }
-  });
+    else if (extensionJson[i].originalmemberof !== extensionJson[i].memberof) {
+      // Find the owning class of the possible mixin
+      const index = componentJson[0].mixes.indexOf(extensionJson[i].originalmemberof);
+      if (index >= 0) {
+        extensionJson[i].inheritedfrom = componentJson[0].mixinOrigins[index];
+      }
+    }
+
+    componentJson.push(extensionJson[i]);
+  }
 }
 
+//
+// Make a copy of a json object. This is typically used to avoid corrupting
+// the cached json in unextendedDocumentationMap.
+//
+function cloneJSON(json) {
+  return JSON.parse(JSON.stringify(json));
+}
+
+//
+// Remove the outputPath folder and contents
+//
+function clean() {
+  const removePromise = promisify(fs.remove);
+  return removePromise(outputPath);
+}
+
+//
+// Creates the outputPath directory
+//
+function createOutputPathDirectory(path) {
+  const ensureDirPromise = promisify(fs.ensureDir);
+  return ensureDirPromise(path);
+}
+
+//
 // Apply the given promise-returning function to each member of the array.
 // Ensure each promise completes before starting the next one to avoid
 // spinning up too many file operations at once. This is effectively like
 // Promise.all(), while ensuring that the items are processed in a completely
 // sequential order.
+//
 function mapAndChain(array, promiseFn) {
+  if (array == null || array.length == 0) {
+    return Promise.resolve();
+  }
+  
   // Start the promise chain with a resolved promise.
   return array.reduce((chain, item) => chain.then(() => promiseFn(item)), Promise.resolve());
 }
 
+function buildDocs() {
+  clean()
+  .then(() => {
+    return createOutputPathDirectory(outputPath);
+  })
+  .then(() => {
+    return buildDocsList();
+  })
+  .then(() => {
+    return mapAndChain(docsList, buildUnextendedJson);
+  })
+  .then(() => {
+    return mapAndChain(docsList, buildAndWriteExtendedJson);
+  });
+}
 
-const docsTask = function() {
-  if (!fs.existsSync(outputPath)) {
-    fs.mkdirSync(outputPath);
-  }
-  
-  return mapAndChain(docsList, doc => buildMarkdownDoc(doc))
-  .then(() => console.log('All documentation complete'))
-  .catch(err => console.log(`error: ${err}`));
-};
-
-module.exports = docsTask;
-docsTask();
+buildDocs();

--- a/shared/APICard.jsx
+++ b/shared/APICard.jsx
@@ -10,6 +10,7 @@ export default class APICard extends Component {
   render(props) {
     // The API member kind (event, method, etc.) determines the card type.
     const cardForKind = {
+      'constant': ConstantCard,
       'function': MethodCard,
       'event': EventCard,
       'member': PropertyCard
@@ -25,9 +26,28 @@ export default class APICard extends Component {
 // Template shared by all API card types.
 function CardTemplate(props) {
 
+  const memberof = props.memberof;
   const originalmemberof = props.originalmemberof;
-  const definedBy = originalmemberof &&
-    (<p>Defined by <a href={originalmemberof}>{originalmemberof}</a></p>);
+  const inheritedfrom = props.inheritedfrom;
+  
+  let definedBy = null;
+  
+  if (originalmemberof 
+      && originalmemberof !== memberof 
+      && inheritedfrom 
+      && inheritedfrom !== originalmemberof 
+      && inheritedfrom !== memberof) {
+    definedBy = (
+      <p>
+        Defined by <a href={originalmemberof}>{originalmemberof}</a> inherited from <a href={inheritedfrom}>{inheritedfrom}</a>
+      </p>);
+  }
+  else if (originalmemberof && inheritedfrom !== memberof) {
+    definedBy = (<p>Inherited from <a href={originalmemberof}>{originalmemberof}</a></p>);
+  }
+  else if (originalmemberof) {
+    definedBy = (<p>Defined by <a href={originalmemberof}>{originalmemberof}</a></p>);
+  }
 
   return (
     <div class="apiCard">
@@ -53,7 +73,9 @@ function EventCard(props) {
       description={props.description}
       heading={heading}
       name={props.name}
+      memberof={props.memberof}
       originalmemberof={props.originalmemberof}
+      inheritedfrom={props.inheritedfrom}
       >
     </CardTemplate>
   );
@@ -93,7 +115,9 @@ function MethodCard(props) {
       description={props.description}
       heading={heading}
       name={props.name}
+      memberof={props.memberof}
       originalmemberof={props.originalmemberof}
+      inheritedfrom={props.inheritedfrom}
       >
       {returns}
       <MethodParameterList parameters={props.params}/>
@@ -155,7 +179,50 @@ function PropertyCard(props) {
       description={props.description}
       heading={heading}
       name={props.name}
+      memberof={props.memberof}
       originalmemberof={props.originalmemberof}
+      inheritedfrom={props.inheritedfrom}
+      >
+      {formattedType}
+      {defaultValue}
+    </CardTemplate>
+  );
+}
+
+//
+// ConstantCard is nearly identical to PropertyCard, but we
+// keep them separated for now should we want further distinction in
+// the display between the two. If we decide the two cards should look
+// near-identical, we can parameterize PropertyCard to handle both cases.
+//
+function ConstantCard(props) {
+
+  const heading = (
+    <span>
+      {props.name}
+      <span class="apiMemberType"> constant</span>
+    </span>
+  );
+
+  const defaultValue = props.defaultvalue && (
+    <p>
+      <span class="apiLabel">Default:</span> <code>{props.defaultvalue}</code>
+    </p>
+  );
+
+  const type = props.type && props.type.names && props.type.names[0];
+  const formattedType = type && (<p>
+    <span class="apiLabel">Type:</span> <code>{type}</code>
+  </p>);
+
+  return (
+    <CardTemplate
+      description={props.description}
+      heading={heading}
+      name={props.name}
+      memberof={props.memberof}
+      originalmemberof={props.originalmemberof}
+      inheritedfrom={props.inheritedfrom}
       >
       {formattedType}
       {defaultValue}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1677,6 +1677,7 @@ elix@elix/elix#master:
     gulp-rename "^1.2.2"
     gulp-saucelabs "^0.1.5"
     gulp-util "^3.0.7"
+    jsdoc-to-markdown "^1.3.3"
     jshint "^2.9.4"
     mocha "^3.2.0"
     sinon "^2.0.0-pre.5"
@@ -2090,6 +2091,13 @@ fs-exists-sync@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz#982d6893af918e72d08dec9e8673ff2b5a8d6add"
 
+fs-extra@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-2.1.2.tgz#046c70163cef9aad46b0e4a7fa467fb22d71de35"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^2.1.0"
+
 fs-readdir-recursive@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz#8cd1745c8b4f8a29c8caec392476921ba195f560"
@@ -2287,7 +2295,7 @@ graceful-fs@^3.0.0:
   dependencies:
     natives "^1.1.0"
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.9:
+graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -2934,6 +2942,12 @@ json3@3.3.2:
 json5@^0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
+
+jsonfile@^2.1.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-2.4.0.tgz#3736a2b428b87bbda0cc83b53fa3d633a35c2ae8"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
 
 jsonify@~0.0.0:
   version "0.0.0"


### PR DESCRIPTION
Support jsDoc extends by extending an object's documentation with its inherited class(es) and associated mixins.